### PR TITLE
Finalize RockyLinux 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 /junit
 /log
 /doc
+/Gemfile.lock

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,15 +7,15 @@
 ### Classes
 
 * [`rkhunter`](#rkhunter): Installs rkhunter and sets up cron job to run rkhunter once per day
-* [`rkhunter::check`](#rkhuntercheck): Add a scheduled job to check the system with rkhunter
-* [`rkhunter::config`](#rkhunterconfig): Configure rkhunter
-* [`rkhunter::install`](#rkhunterinstall): Install rkhunter
-* [`rkhunter::propupd`](#rkhunterpropupd): Immediately update the properties database
-* [`rkhunter::update`](#rkhunterupdate): Add a scheduled job to update rkhunter
+* [`rkhunter::check`](#rkhunter--check): Add a scheduled job to check the system with rkhunter
+* [`rkhunter::config`](#rkhunter--config): Configure rkhunter
+* [`rkhunter::install`](#rkhunter--install): Install rkhunter
+* [`rkhunter::propupd`](#rkhunter--propupd): Immediately update the properties database
+* [`rkhunter::update`](#rkhunter--update): Add a scheduled job to update rkhunter
 
 ### Data types
 
-* [`Rkhunter::BindPath`](#rkhunterbindpath): matches valid binddir path accepts absolute path or an absolute path with a '+' proceeding it
+* [`Rkhunter::BindPath`](#Rkhunter--BindPath): matches valid binddir path accepts absolute path or an absolute path with a '+' proceeding it
 
 ## Classes
 
@@ -27,35 +27,35 @@ Installs rkhunter and sets up cron job to run rkhunter once per day
 
 The following parameters are available in the `rkhunter` class:
 
-* [`check_for_updates`](#check_for_updates)
-* [`enable_system_check`](#enable_system_check)
-* [`install_optional_packages`](#install_optional_packages)
+* [`check_for_updates`](#-rkhunter--check_for_updates)
+* [`enable_system_check`](#-rkhunter--enable_system_check)
+* [`install_optional_packages`](#-rkhunter--install_optional_packages)
 
-##### <a name="check_for_updates"></a>`check_for_updates`
+##### <a name="-rkhunter--check_for_updates"></a>`check_for_updates`
 
 Data type: `Boolean`
 
 Check internet for definition updates
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="enable_system_check"></a>`enable_system_check`
+##### <a name="-rkhunter--enable_system_check"></a>`enable_system_check`
 
 Data type: `Boolean`
 
 Set rkhunter to check the system on a regular basis
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="install_optional_packages"></a>`install_optional_packages`
+##### <a name="-rkhunter--install_optional_packages"></a>`install_optional_packages`
 
 Data type: `Boolean`
 
 Install packages that enhance the capabilities of rkhunter
 
-Default value: ``true``
+Default value: `true`
 
-### <a name="rkhuntercheck"></a>`rkhunter::check`
+### <a name="rkhunter--check"></a>`rkhunter::check`
 
 Add a scheduled job to check the system with rkhunter
 
@@ -63,17 +63,17 @@ Add a scheduled job to check the system with rkhunter
 
 The following parameters are available in the `rkhunter::check` class:
 
-* [`method`](#method)
-* [`systemd_calendar`](#systemd_calendar)
-* [`minute`](#minute)
-* [`hour`](#hour)
-* [`monthday`](#monthday)
-* [`month`](#month)
-* [`weekday`](#weekday)
-* [`path`](#path)
-* [`options`](#options)
+* [`method`](#-rkhunter--check--method)
+* [`systemd_calendar`](#-rkhunter--check--systemd_calendar)
+* [`minute`](#-rkhunter--check--minute)
+* [`hour`](#-rkhunter--check--hour)
+* [`monthday`](#-rkhunter--check--monthday)
+* [`month`](#-rkhunter--check--month)
+* [`weekday`](#-rkhunter--check--weekday)
+* [`path`](#-rkhunter--check--path)
+* [`options`](#-rkhunter--check--options)
 
-##### <a name="method"></a>`method`
+##### <a name="-rkhunter--check--method"></a>`method`
 
 Data type: `Enum['cron','systemd']`
 
@@ -81,7 +81,7 @@ How you wish to schedule the run
 
 Default value: `'systemd'`
 
-##### <a name="systemd_calendar"></a>`systemd_calendar`
+##### <a name="-rkhunter--check--systemd_calendar"></a>`systemd_calendar`
 
 Data type: `Optional[String[1]]`
 
@@ -90,9 +90,9 @@ If `$method` is `systemd`, set this exact calendar string
 This is not verified, use `systemd-analyze calendar` on a modern system to
 ensure that you have a valid string
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="minute"></a>`minute`
+##### <a name="-rkhunter--check--minute"></a>`minute`
 
 Data type: `Simplib::Cron::Minute`
 
@@ -100,7 +100,7 @@ Cron minute
 
 Default value: `fqdn_rand(59)`
 
-##### <a name="hour"></a>`hour`
+##### <a name="-rkhunter--check--hour"></a>`hour`
 
 Data type: `Simplib::Cron::Hour`
 
@@ -108,7 +108,7 @@ Cron hour
 
 Default value: `1`
 
-##### <a name="monthday"></a>`monthday`
+##### <a name="-rkhunter--check--monthday"></a>`monthday`
 
 Data type: `Simplib::Cron::MonthDay`
 
@@ -116,7 +116,7 @@ Cron monthday
 
 Default value: `'*'`
 
-##### <a name="month"></a>`month`
+##### <a name="-rkhunter--check--month"></a>`month`
 
 Data type: `Simplib::Cron::Month`
 
@@ -124,7 +124,7 @@ Cron month
 
 Default value: `'*'`
 
-##### <a name="weekday"></a>`weekday`
+##### <a name="-rkhunter--check--weekday"></a>`weekday`
 
 Data type: `Simplib::Cron::Weekday`
 
@@ -132,7 +132,7 @@ Cron weekday
 
 Default value: `'*'`
 
-##### <a name="path"></a>`path`
+##### <a name="-rkhunter--check--path"></a>`path`
 
 Data type: `Stdlib::Unixpath`
 
@@ -140,7 +140,7 @@ The path to rkhunter
 
 Default value: `'/usr/bin/rkhunter'`
 
-##### <a name="options"></a>`options`
+##### <a name="-rkhunter--check--options"></a>`options`
 
 Data type: `Array[String[1]]`
 
@@ -148,7 +148,7 @@ Extra options to pass to `rkhunter --check`
 
 Default value: `['--skip-keypress', '--quiet']`
 
-### <a name="rkhunterconfig"></a>`rkhunter::config`
+### <a name="rkhunter--config"></a>`rkhunter::config`
 
 Any parameter that is not documented below matches its direct counterpart in
 the `rkhunter.conf` configuration file.
@@ -162,254 +162,254 @@ here relate to either performance or system security safety.
 
 The following parameters are available in the `rkhunter::config` class:
 
-* [`allowdevfile`](#allowdevfile)
-* [`allowhiddendir`](#allowhiddendir)
-* [`allowhiddenfile`](#allowhiddenfile)
-* [`user_fileprop_files_dirs`](#user_fileprop_files_dirs)
-* [`allowipcpid`](#allowipcpid)
-* [`allowipcproc`](#allowipcproc)
-* [`allowipcuser`](#allowipcuser)
-* [`allowprocdelfile`](#allowprocdelfile)
-* [`allowproclisten`](#allowproclisten)
-* [`allowpromiscif`](#allowpromiscif)
-* [`allow_ssh_prot_v1`](#allow_ssh_prot_v1)
-* [`allow_ssh_root_user`](#allow_ssh_root_user)
-* [`allow_syslog_remote_logging`](#allow_syslog_remote_logging)
-* [`append_log`](#append_log)
-* [`app_whitelist`](#app_whitelist)
-* [`attrwhitelist`](#attrwhitelist)
-* [`auto_x_detect`](#auto_x_detect)
-* [`bindir`](#bindir)
-* [`color_set2`](#color_set2)
-* [`copy_log_on_error`](#copy_log_on_error)
-* [`dbdir`](#dbdir)
-* [`disable_tests`](#disable_tests)
-* [`empty_logfiles`](#empty_logfiles)
-* [`enable_tests`](#enable_tests)
-* [`epoch_date_cmd`](#epoch_date_cmd)
-* [`exclude_user_fileprop_files_dirs`](#exclude_user_fileprop_files_dirs)
-* [`existwhitelist`](#existwhitelist)
-* [`globstar`](#globstar)
-* [`hash_cmd`](#hash_cmd)
-* [`hash_fld_idx`](#hash_fld_idx)
-* [`ignore_prelink_dep_err`](#ignore_prelink_dep_err)
-* [`immutable_set`](#immutable_set)
-* [`immutwhitelist`](#immutwhitelist)
-* [`inetd_allowed_svc`](#inetd_allowed_svc)
-* [`inetd_conf_path`](#inetd_conf_path)
-* [`installdir`](#installdir)
-* [`ipc_seg_size`](#ipc_seg_size)
-* [`language`](#language)
-* [`lock_timeout`](#lock_timeout)
-* [`lockdir`](#lockdir)
-* [`logfile`](#logfile)
-* [`mail_on_warning`](#mail_on_warning)
-* [`mail_cmd`](#mail_cmd)
-* [`mirrors_mode`](#mirrors_mode)
-* [`missing_logfiles`](#missing_logfiles)
-* [`modules_dir`](#modules_dir)
-* [`os_version_file`](#os_version_file)
-* [`password_file`](#password_file)
-* [`phalanx2_dirtest`](#phalanx2_dirtest)
-* [`pkgmgr_no_vrfy`](#pkgmgr_no_vrfy)
-* [`pkgmgr`](#pkgmgr)
-* [`port_path_whitelist`](#port_path_whitelist)
-* [`tcp_port_whitelist`](#tcp_port_whitelist)
-* [`udp_port_whitelist`](#udp_port_whitelist)
-* [`pwdless_accounts`](#pwdless_accounts)
-* [`readlink_cmd`](#readlink_cmd)
-* [`rotate_mirrors`](#rotate_mirrors)
-* [`rtkt_dir_whitelist`](#rtkt_dir_whitelist)
-* [`rtkt_file_whitelist`](#rtkt_file_whitelist)
-* [`scan_mode_dev`](#scan_mode_dev)
-* [`scanrootkitmode`](#scanrootkitmode)
-* [`scriptdir`](#scriptdir)
-* [`scriptwhitelist`](#scriptwhitelist)
-* [`shared_lib_whitelist`](#shared_lib_whitelist)
-* [`show_lock_msgs`](#show_lock_msgs)
-* [`show_summary_time`](#show_summary_time)
-* [`show_summary_warnings_number`](#show_summary_warnings_number)
-* [`skip_inode_check`](#skip_inode_check)
-* [`ssh_config_dir`](#ssh_config_dir)
-* [`startup_paths`](#startup_paths)
-* [`stat_cmd`](#stat_cmd)
-* [`suspscan_dirs`](#suspscan_dirs)
-* [`suspscan_maxsize`](#suspscan_maxsize)
-* [`suspscan_temp`](#suspscan_temp)
-* [`suspscan_thresh`](#suspscan_thresh)
-* [`suspscan_whitelist`](#suspscan_whitelist)
-* [`syslog_config_file`](#syslog_config_file)
-* [`tmpdir`](#tmpdir)
-* [`uid0_accounts`](#uid0_accounts)
-* [`unhide_tests`](#unhide_tests)
-* [`unhidetcp_opts`](#unhidetcp_opts)
-* [`update_lang`](#update_lang)
-* [`update_mirrors`](#update_mirrors)
-* [`updt_on_os_change`](#updt_on_os_change)
-* [`use_locking`](#use_locking)
-* [`use_sunsum`](#use_sunsum)
-* [`syslog_priority`](#syslog_priority)
-* [`use_syslog`](#use_syslog)
-* [`warn_on_os_change`](#warn_on_os_change)
-* [`web_cmd`](#web_cmd)
-* [`whitelisted_is_white`](#whitelisted_is_white)
-* [`writewhitelist`](#writewhitelist)
-* [`xinetd_allowed_svc`](#xinetd_allowed_svc)
-* [`xinetd_conf_path`](#xinetd_conf_path)
+* [`allowdevfile`](#-rkhunter--config--allowdevfile)
+* [`allowhiddendir`](#-rkhunter--config--allowhiddendir)
+* [`allowhiddenfile`](#-rkhunter--config--allowhiddenfile)
+* [`user_fileprop_files_dirs`](#-rkhunter--config--user_fileprop_files_dirs)
+* [`allowipcpid`](#-rkhunter--config--allowipcpid)
+* [`allowipcproc`](#-rkhunter--config--allowipcproc)
+* [`allowipcuser`](#-rkhunter--config--allowipcuser)
+* [`allowprocdelfile`](#-rkhunter--config--allowprocdelfile)
+* [`allowproclisten`](#-rkhunter--config--allowproclisten)
+* [`allowpromiscif`](#-rkhunter--config--allowpromiscif)
+* [`allow_ssh_prot_v1`](#-rkhunter--config--allow_ssh_prot_v1)
+* [`allow_ssh_root_user`](#-rkhunter--config--allow_ssh_root_user)
+* [`allow_syslog_remote_logging`](#-rkhunter--config--allow_syslog_remote_logging)
+* [`append_log`](#-rkhunter--config--append_log)
+* [`app_whitelist`](#-rkhunter--config--app_whitelist)
+* [`attrwhitelist`](#-rkhunter--config--attrwhitelist)
+* [`auto_x_detect`](#-rkhunter--config--auto_x_detect)
+* [`bindir`](#-rkhunter--config--bindir)
+* [`color_set2`](#-rkhunter--config--color_set2)
+* [`copy_log_on_error`](#-rkhunter--config--copy_log_on_error)
+* [`dbdir`](#-rkhunter--config--dbdir)
+* [`disable_tests`](#-rkhunter--config--disable_tests)
+* [`empty_logfiles`](#-rkhunter--config--empty_logfiles)
+* [`enable_tests`](#-rkhunter--config--enable_tests)
+* [`epoch_date_cmd`](#-rkhunter--config--epoch_date_cmd)
+* [`exclude_user_fileprop_files_dirs`](#-rkhunter--config--exclude_user_fileprop_files_dirs)
+* [`existwhitelist`](#-rkhunter--config--existwhitelist)
+* [`globstar`](#-rkhunter--config--globstar)
+* [`hash_cmd`](#-rkhunter--config--hash_cmd)
+* [`hash_fld_idx`](#-rkhunter--config--hash_fld_idx)
+* [`ignore_prelink_dep_err`](#-rkhunter--config--ignore_prelink_dep_err)
+* [`immutable_set`](#-rkhunter--config--immutable_set)
+* [`immutwhitelist`](#-rkhunter--config--immutwhitelist)
+* [`inetd_allowed_svc`](#-rkhunter--config--inetd_allowed_svc)
+* [`inetd_conf_path`](#-rkhunter--config--inetd_conf_path)
+* [`installdir`](#-rkhunter--config--installdir)
+* [`ipc_seg_size`](#-rkhunter--config--ipc_seg_size)
+* [`language`](#-rkhunter--config--language)
+* [`lock_timeout`](#-rkhunter--config--lock_timeout)
+* [`lockdir`](#-rkhunter--config--lockdir)
+* [`logfile`](#-rkhunter--config--logfile)
+* [`mail_on_warning`](#-rkhunter--config--mail_on_warning)
+* [`mail_cmd`](#-rkhunter--config--mail_cmd)
+* [`mirrors_mode`](#-rkhunter--config--mirrors_mode)
+* [`missing_logfiles`](#-rkhunter--config--missing_logfiles)
+* [`modules_dir`](#-rkhunter--config--modules_dir)
+* [`os_version_file`](#-rkhunter--config--os_version_file)
+* [`password_file`](#-rkhunter--config--password_file)
+* [`phalanx2_dirtest`](#-rkhunter--config--phalanx2_dirtest)
+* [`pkgmgr_no_vrfy`](#-rkhunter--config--pkgmgr_no_vrfy)
+* [`pkgmgr`](#-rkhunter--config--pkgmgr)
+* [`port_path_whitelist`](#-rkhunter--config--port_path_whitelist)
+* [`tcp_port_whitelist`](#-rkhunter--config--tcp_port_whitelist)
+* [`udp_port_whitelist`](#-rkhunter--config--udp_port_whitelist)
+* [`pwdless_accounts`](#-rkhunter--config--pwdless_accounts)
+* [`readlink_cmd`](#-rkhunter--config--readlink_cmd)
+* [`rotate_mirrors`](#-rkhunter--config--rotate_mirrors)
+* [`rtkt_dir_whitelist`](#-rkhunter--config--rtkt_dir_whitelist)
+* [`rtkt_file_whitelist`](#-rkhunter--config--rtkt_file_whitelist)
+* [`scan_mode_dev`](#-rkhunter--config--scan_mode_dev)
+* [`scanrootkitmode`](#-rkhunter--config--scanrootkitmode)
+* [`scriptdir`](#-rkhunter--config--scriptdir)
+* [`scriptwhitelist`](#-rkhunter--config--scriptwhitelist)
+* [`shared_lib_whitelist`](#-rkhunter--config--shared_lib_whitelist)
+* [`show_lock_msgs`](#-rkhunter--config--show_lock_msgs)
+* [`show_summary_time`](#-rkhunter--config--show_summary_time)
+* [`show_summary_warnings_number`](#-rkhunter--config--show_summary_warnings_number)
+* [`skip_inode_check`](#-rkhunter--config--skip_inode_check)
+* [`ssh_config_dir`](#-rkhunter--config--ssh_config_dir)
+* [`startup_paths`](#-rkhunter--config--startup_paths)
+* [`stat_cmd`](#-rkhunter--config--stat_cmd)
+* [`suspscan_dirs`](#-rkhunter--config--suspscan_dirs)
+* [`suspscan_maxsize`](#-rkhunter--config--suspscan_maxsize)
+* [`suspscan_temp`](#-rkhunter--config--suspscan_temp)
+* [`suspscan_thresh`](#-rkhunter--config--suspscan_thresh)
+* [`suspscan_whitelist`](#-rkhunter--config--suspscan_whitelist)
+* [`syslog_config_file`](#-rkhunter--config--syslog_config_file)
+* [`tmpdir`](#-rkhunter--config--tmpdir)
+* [`uid0_accounts`](#-rkhunter--config--uid0_accounts)
+* [`unhide_tests`](#-rkhunter--config--unhide_tests)
+* [`unhidetcp_opts`](#-rkhunter--config--unhidetcp_opts)
+* [`update_lang`](#-rkhunter--config--update_lang)
+* [`update_mirrors`](#-rkhunter--config--update_mirrors)
+* [`updt_on_os_change`](#-rkhunter--config--updt_on_os_change)
+* [`use_locking`](#-rkhunter--config--use_locking)
+* [`use_sunsum`](#-rkhunter--config--use_sunsum)
+* [`syslog_priority`](#-rkhunter--config--syslog_priority)
+* [`use_syslog`](#-rkhunter--config--use_syslog)
+* [`warn_on_os_change`](#-rkhunter--config--warn_on_os_change)
+* [`web_cmd`](#-rkhunter--config--web_cmd)
+* [`whitelisted_is_white`](#-rkhunter--config--whitelisted_is_white)
+* [`writewhitelist`](#-rkhunter--config--writewhitelist)
+* [`xinetd_allowed_svc`](#-rkhunter--config--xinetd_allowed_svc)
+* [`xinetd_conf_path`](#-rkhunter--config--xinetd_conf_path)
 
-##### <a name="allowdevfile"></a>`allowdevfile`
-
-Data type: `Array[Stdlib::Unixpath]`
-
-In module data
-
-##### <a name="allowhiddendir"></a>`allowhiddendir`
+##### <a name="-rkhunter--config--allowdevfile"></a>`allowdevfile`
 
 Data type: `Array[Stdlib::Unixpath]`
 
 In module data
 
-##### <a name="allowhiddenfile"></a>`allowhiddenfile`
+##### <a name="-rkhunter--config--allowhiddendir"></a>`allowhiddendir`
 
 Data type: `Array[Stdlib::Unixpath]`
 
 In module data
 
-##### <a name="user_fileprop_files_dirs"></a>`user_fileprop_files_dirs`
+##### <a name="-rkhunter--config--allowhiddenfile"></a>`allowhiddenfile`
 
 Data type: `Array[Stdlib::Unixpath]`
 
 In module data
 
-##### <a name="allowipcpid"></a>`allowipcpid`
+##### <a name="-rkhunter--config--user_fileprop_files_dirs"></a>`user_fileprop_files_dirs`
+
+Data type: `Array[Stdlib::Unixpath]`
+
+In module data
+
+##### <a name="-rkhunter--config--allowipcpid"></a>`allowipcpid`
 
 Data type: `Optional[Array[Integer[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="allowipcproc"></a>`allowipcproc`
+##### <a name="-rkhunter--config--allowipcproc"></a>`allowipcproc`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="allowipcuser"></a>`allowipcuser`
+##### <a name="-rkhunter--config--allowipcuser"></a>`allowipcuser`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="allowprocdelfile"></a>`allowprocdelfile`
-
-Data type: `Optional[Array[Stdlib::Unixpath]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="allowproclisten"></a>`allowproclisten`
+##### <a name="-rkhunter--config--allowprocdelfile"></a>`allowprocdelfile`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="allowpromiscif"></a>`allowpromiscif`
+##### <a name="-rkhunter--config--allowproclisten"></a>`allowproclisten`
+
+Data type: `Optional[Array[Stdlib::Unixpath]]`
+
+
+
+Default value: `undef`
+
+##### <a name="-rkhunter--config--allowpromiscif"></a>`allowpromiscif`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="allow_ssh_prot_v1"></a>`allow_ssh_prot_v1`
+##### <a name="-rkhunter--config--allow_ssh_prot_v1"></a>`allow_ssh_prot_v1`
 
 Data type: `Boolean`
 
 
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="allow_ssh_root_user"></a>`allow_ssh_root_user`
+##### <a name="-rkhunter--config--allow_ssh_root_user"></a>`allow_ssh_root_user`
 
 Data type: `Variant[Boolean,Enum['unset']]`
 
 
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="allow_syslog_remote_logging"></a>`allow_syslog_remote_logging`
-
-Data type: `Boolean`
-
-
-
-Default value: ``true``
-
-##### <a name="append_log"></a>`append_log`
+##### <a name="-rkhunter--config--allow_syslog_remote_logging"></a>`allow_syslog_remote_logging`
 
 Data type: `Boolean`
 
 
 
-Default value: ``false``
+Default value: `true`
 
-##### <a name="app_whitelist"></a>`app_whitelist`
+##### <a name="-rkhunter--config--append_log"></a>`append_log`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
+
+##### <a name="-rkhunter--config--app_whitelist"></a>`app_whitelist`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="attrwhitelist"></a>`attrwhitelist`
+##### <a name="-rkhunter--config--attrwhitelist"></a>`attrwhitelist`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="auto_x_detect"></a>`auto_x_detect`
+##### <a name="-rkhunter--config--auto_x_detect"></a>`auto_x_detect`
 
 Data type: `Boolean`
 
 
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="bindir"></a>`bindir`
+##### <a name="-rkhunter--config--bindir"></a>`bindir`
 
 Data type: `Optional[Array[Rkhunter::BindPath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="color_set2"></a>`color_set2`
-
-Data type: `Boolean`
-
-
-
-Default value: ``false``
-
-##### <a name="copy_log_on_error"></a>`copy_log_on_error`
+##### <a name="-rkhunter--config--color_set2"></a>`color_set2`
 
 Data type: `Boolean`
 
 
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="dbdir"></a>`dbdir`
+##### <a name="-rkhunter--config--copy_log_on_error"></a>`copy_log_on_error`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
+
+##### <a name="-rkhunter--config--dbdir"></a>`dbdir`
 
 Data type: `Stdlib::Unixpath`
 
@@ -417,7 +417,7 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `'/var/lib/rkhunter/db'`
 
-##### <a name="disable_tests"></a>`disable_tests`
+##### <a name="-rkhunter--config--disable_tests"></a>`disable_tests`
 
 Data type: `Array[String]`
 
@@ -427,15 +427,15 @@ nature and the fact they are prone to false positives.
 
 Default value: `['suspscan', 'hidden_ports', 'hidden_procs', 'deleted_files', 'packet_cap_apps', 'apps']`
 
-##### <a name="empty_logfiles"></a>`empty_logfiles`
+##### <a name="-rkhunter--config--empty_logfiles"></a>`empty_logfiles`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="enable_tests"></a>`enable_tests`
+##### <a name="-rkhunter--config--enable_tests"></a>`enable_tests`
 
 Data type: `Array[String[1]]`
 
@@ -443,95 +443,95 @@ Data type: `Array[String[1]]`
 
 Default value: `['ALL']`
 
-##### <a name="epoch_date_cmd"></a>`epoch_date_cmd`
+##### <a name="-rkhunter--config--epoch_date_cmd"></a>`epoch_date_cmd`
 
 Data type: `Optional[String[1]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="exclude_user_fileprop_files_dirs"></a>`exclude_user_fileprop_files_dirs`
-
-Data type: `Optional[Array[Stdlib::Unixpath]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="existwhitelist"></a>`existwhitelist`
+##### <a name="-rkhunter--config--exclude_user_fileprop_files_dirs"></a>`exclude_user_fileprop_files_dirs`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="globstar"></a>`globstar`
+##### <a name="-rkhunter--config--existwhitelist"></a>`existwhitelist`
+
+Data type: `Optional[Array[Stdlib::Unixpath]]`
+
+
+
+Default value: `undef`
+
+##### <a name="-rkhunter--config--globstar"></a>`globstar`
 
 Data type: `Boolean`
 
 
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="hash_cmd"></a>`hash_cmd`
+##### <a name="-rkhunter--config--hash_cmd"></a>`hash_cmd`
 
 Data type: `Optional[String[1]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="hash_fld_idx"></a>`hash_fld_idx`
+##### <a name="-rkhunter--config--hash_fld_idx"></a>`hash_fld_idx`
 
 Data type: `Optional[Integer[1]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="ignore_prelink_dep_err"></a>`ignore_prelink_dep_err`
+##### <a name="-rkhunter--config--ignore_prelink_dep_err"></a>`ignore_prelink_dep_err`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="immutable_set"></a>`immutable_set`
+##### <a name="-rkhunter--config--immutable_set"></a>`immutable_set`
 
 Data type: `Boolean`
 
 
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="immutwhitelist"></a>`immutwhitelist`
+##### <a name="-rkhunter--config--immutwhitelist"></a>`immutwhitelist`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="inetd_allowed_svc"></a>`inetd_allowed_svc`
+##### <a name="-rkhunter--config--inetd_allowed_svc"></a>`inetd_allowed_svc`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="inetd_conf_path"></a>`inetd_conf_path`
+##### <a name="-rkhunter--config--inetd_conf_path"></a>`inetd_conf_path`
 
 Data type: `Optional[Stdlib::Unixpath]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="installdir"></a>`installdir`
+##### <a name="-rkhunter--config--installdir"></a>`installdir`
 
 Data type: `Stdlib::Unixpath`
 
@@ -539,31 +539,31 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `'/usr'`
 
-##### <a name="ipc_seg_size"></a>`ipc_seg_size`
+##### <a name="-rkhunter--config--ipc_seg_size"></a>`ipc_seg_size`
 
 Data type: `Optional[Integer[1]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="language"></a>`language`
+##### <a name="-rkhunter--config--language"></a>`language`
 
 Data type: `Optional[String[1]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="lock_timeout"></a>`lock_timeout`
+##### <a name="-rkhunter--config--lock_timeout"></a>`lock_timeout`
 
 Data type: `Optional[Integer[1]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="lockdir"></a>`lockdir`
+##### <a name="-rkhunter--config--lockdir"></a>`lockdir`
 
 Data type: `Stdlib::Unixpath`
 
@@ -571,7 +571,7 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `'/var/run/lock'`
 
-##### <a name="logfile"></a>`logfile`
+##### <a name="-rkhunter--config--logfile"></a>`logfile`
 
 Data type: `Stdlib::Unixpath`
 
@@ -579,15 +579,15 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `'/var/log/rkhunter/rkhunter.log'`
 
-##### <a name="mail_on_warning"></a>`mail_on_warning`
+##### <a name="-rkhunter--config--mail_on_warning"></a>`mail_on_warning`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="mail_cmd"></a>`mail_cmd`
+##### <a name="-rkhunter--config--mail_cmd"></a>`mail_cmd`
 
 Data type: `String[1]`
 
@@ -595,7 +595,7 @@ Data type: `String[1]`
 
 Default value: `'mail -s "[rkhunter] Warnings found for ${HOST_NAME}"'`
 
-##### <a name="mirrors_mode"></a>`mirrors_mode`
+##### <a name="-rkhunter--config--mirrors_mode"></a>`mirrors_mode`
 
 Data type: `Enum['any','local','remote']`
 
@@ -603,55 +603,55 @@ Data type: `Enum['any','local','remote']`
 
 Default value: `'any'`
 
-##### <a name="missing_logfiles"></a>`missing_logfiles`
+##### <a name="-rkhunter--config--missing_logfiles"></a>`missing_logfiles`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="modules_dir"></a>`modules_dir`
-
-Data type: `Optional[Stdlib::Unixpath]`
-
-
-
-Default value: ``undef``
-
-##### <a name="os_version_file"></a>`os_version_file`
+##### <a name="-rkhunter--config--modules_dir"></a>`modules_dir`
 
 Data type: `Optional[Stdlib::Unixpath]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="password_file"></a>`password_file`
+##### <a name="-rkhunter--config--os_version_file"></a>`os_version_file`
 
 Data type: `Optional[Stdlib::Unixpath]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="phalanx2_dirtest"></a>`phalanx2_dirtest`
+##### <a name="-rkhunter--config--password_file"></a>`password_file`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+
+
+Default value: `undef`
+
+##### <a name="-rkhunter--config--phalanx2_dirtest"></a>`phalanx2_dirtest`
 
 Data type: `Boolean`
 
 
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="pkgmgr_no_vrfy"></a>`pkgmgr_no_vrfy`
+##### <a name="-rkhunter--config--pkgmgr_no_vrfy"></a>`pkgmgr_no_vrfy`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="pkgmgr"></a>`pkgmgr`
+##### <a name="-rkhunter--config--pkgmgr"></a>`pkgmgr`
 
 Data type: `String[1]`
 
@@ -659,71 +659,71 @@ Data type: `String[1]`
 
 Default value: `'RPM'`
 
-##### <a name="port_path_whitelist"></a>`port_path_whitelist`
+##### <a name="-rkhunter--config--port_path_whitelist"></a>`port_path_whitelist`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="tcp_port_whitelist"></a>`tcp_port_whitelist`
+##### <a name="-rkhunter--config--tcp_port_whitelist"></a>`tcp_port_whitelist`
 
 Data type: `Optional[Array[Simplib::Port]]`
 
 TCP Ports to add to the PORT_WHITELIST option
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="udp_port_whitelist"></a>`udp_port_whitelist`
+##### <a name="-rkhunter--config--udp_port_whitelist"></a>`udp_port_whitelist`
 
 Data type: `Optional[Array[Simplib::Port]]`
 
 UDP Ports to add to the PORT_WHITELIST option
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="pwdless_accounts"></a>`pwdless_accounts`
+##### <a name="-rkhunter--config--pwdless_accounts"></a>`pwdless_accounts`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="readlink_cmd"></a>`readlink_cmd`
+##### <a name="-rkhunter--config--readlink_cmd"></a>`readlink_cmd`
 
 Data type: `Optional[String[1]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="rotate_mirrors"></a>`rotate_mirrors`
+##### <a name="-rkhunter--config--rotate_mirrors"></a>`rotate_mirrors`
 
 Data type: `Boolean`
 
 
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="rtkt_dir_whitelist"></a>`rtkt_dir_whitelist`
-
-Data type: `Optional[Array[Stdlib::Unixpath]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="rtkt_file_whitelist"></a>`rtkt_file_whitelist`
+##### <a name="-rkhunter--config--rtkt_dir_whitelist"></a>`rtkt_dir_whitelist`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="scan_mode_dev"></a>`scan_mode_dev`
+##### <a name="-rkhunter--config--rtkt_file_whitelist"></a>`rtkt_file_whitelist`
+
+Data type: `Optional[Array[Stdlib::Unixpath]]`
+
+
+
+Default value: `undef`
+
+##### <a name="-rkhunter--config--scan_mode_dev"></a>`scan_mode_dev`
 
 Data type: `Enum['THOROUGH','LAZY']`
 
@@ -731,16 +731,16 @@ Data type: `Enum['THOROUGH','LAZY']`
 
 Default value: `'THOROUGH'`
 
-##### <a name="scanrootkitmode"></a>`scanrootkitmode`
+##### <a name="-rkhunter--config--scanrootkitmode"></a>`scanrootkitmode`
 
 Data type: `Boolean`
 
 WARNING: Do not enable this parameter unless you 100% understand what it
 can do to your system performance!
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="scriptdir"></a>`scriptdir`
+##### <a name="-rkhunter--config--scriptdir"></a>`scriptdir`
 
 Data type: `Stdlib::Unixpath`
 
@@ -748,31 +748,31 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `'/usr/share/rkhunter/scripts'`
 
-##### <a name="scriptwhitelist"></a>`scriptwhitelist`
+##### <a name="-rkhunter--config--scriptwhitelist"></a>`scriptwhitelist`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="shared_lib_whitelist"></a>`shared_lib_whitelist`
+##### <a name="-rkhunter--config--shared_lib_whitelist"></a>`shared_lib_whitelist`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="show_lock_msgs"></a>`show_lock_msgs`
+##### <a name="-rkhunter--config--show_lock_msgs"></a>`show_lock_msgs`
 
 Data type: `Boolean`
 
 
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="show_summary_time"></a>`show_summary_time`
+##### <a name="-rkhunter--config--show_summary_time"></a>`show_summary_time`
 
 Data type: `Integer[0,3]`
 
@@ -780,55 +780,55 @@ Data type: `Integer[0,3]`
 
 Default value: `3`
 
-##### <a name="show_summary_warnings_number"></a>`show_summary_warnings_number`
+##### <a name="-rkhunter--config--show_summary_warnings_number"></a>`show_summary_warnings_number`
 
 Data type: `Boolean`
 
 
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="skip_inode_check"></a>`skip_inode_check`
+##### <a name="-rkhunter--config--skip_inode_check"></a>`skip_inode_check`
 
 Data type: `Boolean`
 
 
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="ssh_config_dir"></a>`ssh_config_dir`
+##### <a name="-rkhunter--config--ssh_config_dir"></a>`ssh_config_dir`
 
 Data type: `Optional[Stdlib::Unixpath]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="startup_paths"></a>`startup_paths`
+##### <a name="-rkhunter--config--startup_paths"></a>`startup_paths`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="stat_cmd"></a>`stat_cmd`
+##### <a name="-rkhunter--config--stat_cmd"></a>`stat_cmd`
 
 Data type: `Optional[String[1]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="suspscan_dirs"></a>`suspscan_dirs`
+##### <a name="-rkhunter--config--suspscan_dirs"></a>`suspscan_dirs`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="suspscan_maxsize"></a>`suspscan_maxsize`
+##### <a name="-rkhunter--config--suspscan_maxsize"></a>`suspscan_maxsize`
 
 Data type: `Integer[0]`
 
@@ -836,7 +836,7 @@ Data type: `Integer[0]`
 
 Default value: `1024000`
 
-##### <a name="suspscan_temp"></a>`suspscan_temp`
+##### <a name="-rkhunter--config--suspscan_temp"></a>`suspscan_temp`
 
 Data type: `Stdlib::Unixpath`
 
@@ -844,7 +844,7 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `'/dev/shm'`
 
-##### <a name="suspscan_thresh"></a>`suspscan_thresh`
+##### <a name="-rkhunter--config--suspscan_thresh"></a>`suspscan_thresh`
 
 Data type: `Integer[0]`
 
@@ -852,23 +852,23 @@ Data type: `Integer[0]`
 
 Default value: `200`
 
-##### <a name="suspscan_whitelist"></a>`suspscan_whitelist`
+##### <a name="-rkhunter--config--suspscan_whitelist"></a>`suspscan_whitelist`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="syslog_config_file"></a>`syslog_config_file`
+##### <a name="-rkhunter--config--syslog_config_file"></a>`syslog_config_file`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="tmpdir"></a>`tmpdir`
+##### <a name="-rkhunter--config--tmpdir"></a>`tmpdir`
 
 Data type: `Stdlib::Unixpath`
 
@@ -876,71 +876,71 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `'/var/lib/rkhunter'`
 
-##### <a name="uid0_accounts"></a>`uid0_accounts`
+##### <a name="-rkhunter--config--uid0_accounts"></a>`uid0_accounts`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="unhide_tests"></a>`unhide_tests`
-
-Data type: `Optional[Array[String[1]]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="unhidetcp_opts"></a>`unhidetcp_opts`
+##### <a name="-rkhunter--config--unhide_tests"></a>`unhide_tests`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="update_lang"></a>`update_lang`
+##### <a name="-rkhunter--config--unhidetcp_opts"></a>`unhidetcp_opts`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="update_mirrors"></a>`update_mirrors`
+##### <a name="-rkhunter--config--update_lang"></a>`update_lang`
 
-Data type: `Boolean`
-
-
-
-Default value: ``true``
-
-##### <a name="updt_on_os_change"></a>`updt_on_os_change`
-
-Data type: `Boolean`
+Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``false``
+Default value: `undef`
 
-##### <a name="use_locking"></a>`use_locking`
+##### <a name="-rkhunter--config--update_mirrors"></a>`update_mirrors`
 
 Data type: `Boolean`
 
 
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="use_sunsum"></a>`use_sunsum`
+##### <a name="-rkhunter--config--updt_on_os_change"></a>`updt_on_os_change`
 
 Data type: `Boolean`
 
 
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="syslog_priority"></a>`syslog_priority`
+##### <a name="-rkhunter--config--use_locking"></a>`use_locking`
+
+Data type: `Boolean`
+
+
+
+Default value: `true`
+
+##### <a name="-rkhunter--config--use_sunsum"></a>`use_sunsum`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
+
+##### <a name="-rkhunter--config--syslog_priority"></a>`syslog_priority`
 
 Data type: `Simplib::Syslog::Priority`
 
@@ -948,63 +948,63 @@ Data type: `Simplib::Syslog::Priority`
 
 Default value: `'LOCAL6.NOTICE'`
 
-##### <a name="use_syslog"></a>`use_syslog`
+##### <a name="-rkhunter--config--use_syslog"></a>`use_syslog`
 
 Data type: `Boolean`
 
 
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="warn_on_os_change"></a>`warn_on_os_change`
+##### <a name="-rkhunter--config--warn_on_os_change"></a>`warn_on_os_change`
 
 Data type: `Boolean`
 
 
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="web_cmd"></a>`web_cmd`
+##### <a name="-rkhunter--config--web_cmd"></a>`web_cmd`
 
 Data type: `Optional[String[1]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="whitelisted_is_white"></a>`whitelisted_is_white`
+##### <a name="-rkhunter--config--whitelisted_is_white"></a>`whitelisted_is_white`
 
 Data type: `Boolean`
 
 
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="writewhitelist"></a>`writewhitelist`
+##### <a name="-rkhunter--config--writewhitelist"></a>`writewhitelist`
 
 Data type: `Optional[Array[Stdlib::Unixpath]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="xinetd_allowed_svc"></a>`xinetd_allowed_svc`
+##### <a name="-rkhunter--config--xinetd_allowed_svc"></a>`xinetd_allowed_svc`
 
 Data type: `Optional[Array[String[1]]]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="xinetd_conf_path"></a>`xinetd_conf_path`
+##### <a name="-rkhunter--config--xinetd_conf_path"></a>`xinetd_conf_path`
 
 Data type: `Optional[Stdlib::Unixpath]`
 
 
 
-Default value: ``undef``
+Default value: `undef`
 
-### <a name="rkhunterinstall"></a>`rkhunter::install`
+### <a name="rkhunter--install"></a>`rkhunter::install`
 
 Install rkhunter
 
@@ -1012,12 +1012,12 @@ Install rkhunter
 
 The following parameters are available in the `rkhunter::install` class:
 
-* [`install_optional_packages`](#install_optional_packages)
-* [`optional_packages`](#optional_packages)
-* [`optional_package_ensure`](#optional_package_ensure)
-* [`rkhunter_package_ensure`](#rkhunter_package_ensure)
+* [`install_optional_packages`](#-rkhunter--install--install_optional_packages)
+* [`optional_packages`](#-rkhunter--install--optional_packages)
+* [`optional_package_ensure`](#-rkhunter--install--optional_package_ensure)
+* [`rkhunter_package_ensure`](#-rkhunter--install--rkhunter_package_ensure)
 
-##### <a name="install_optional_packages"></a>`install_optional_packages`
+##### <a name="-rkhunter--install--install_optional_packages"></a>`install_optional_packages`
 
 Data type: `Boolean`
 
@@ -1025,7 +1025,7 @@ Install optional packages that enable additional functionality in rkhunter
 
 Default value: `$rkhunter::install_optional_packages`
 
-##### <a name="optional_packages"></a>`optional_packages`
+##### <a name="-rkhunter--install--optional_packages"></a>`optional_packages`
 
 Data type: `Optional[Variant[Hash[String[1],Hash],Array[String[1]]]]`
 
@@ -1034,9 +1034,9 @@ The list of optional packages to be installed
 This may be anything that the puppetlabs-stdlib ``ensure_packages``
 function accepts
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="optional_package_ensure"></a>`optional_package_ensure`
+##### <a name="-rkhunter--install--optional_package_ensure"></a>`optional_package_ensure`
 
 Data type: `Simplib::PackageEnsure`
 
@@ -1044,7 +1044,7 @@ The state in which to place all packages
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-##### <a name="rkhunter_package_ensure"></a>`rkhunter_package_ensure`
+##### <a name="-rkhunter--install--rkhunter_package_ensure"></a>`rkhunter_package_ensure`
 
 Data type: `String[1]`
 
@@ -1053,7 +1053,7 @@ pinned.
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-### <a name="rkhunterpropupd"></a>`rkhunter::propupd`
+### <a name="rkhunter--propupd"></a>`rkhunter::propupd`
 
 Needed so that each run after installation does not trigger false positives
 
@@ -1061,24 +1061,24 @@ Needed so that each run after installation does not trigger false positives
 
 The following parameters are available in the `rkhunter::propupd` class:
 
-* [`datfile`](#datfile)
-* [`enable`](#enable)
+* [`datfile`](#-rkhunter--propupd--datfile)
+* [`enable`](#-rkhunter--propupd--enable)
 
-##### <a name="datfile"></a>`datfile`
+##### <a name="-rkhunter--propupd--datfile"></a>`datfile`
 
 Data type: `Stdlib::Unixpath`
 
 
 
-##### <a name="enable"></a>`enable`
+##### <a name="-rkhunter--propupd--enable"></a>`enable`
 
 Data type: `Boolean`
 
 
 
-Default value: ``true``
+Default value: `true`
 
-### <a name="rkhunterupdate"></a>`rkhunter::update`
+### <a name="rkhunter--update"></a>`rkhunter::update`
 
 Add a scheduled job to update rkhunter
 
@@ -1086,17 +1086,17 @@ Add a scheduled job to update rkhunter
 
 The following parameters are available in the `rkhunter::update` class:
 
-* [`method`](#method)
-* [`systemd_calendar`](#systemd_calendar)
-* [`minute`](#minute)
-* [`hour`](#hour)
-* [`monthday`](#monthday)
-* [`month`](#month)
-* [`weekday`](#weekday)
-* [`options`](#options)
-* [`path`](#path)
+* [`method`](#-rkhunter--update--method)
+* [`systemd_calendar`](#-rkhunter--update--systemd_calendar)
+* [`minute`](#-rkhunter--update--minute)
+* [`hour`](#-rkhunter--update--hour)
+* [`monthday`](#-rkhunter--update--monthday)
+* [`month`](#-rkhunter--update--month)
+* [`weekday`](#-rkhunter--update--weekday)
+* [`options`](#-rkhunter--update--options)
+* [`path`](#-rkhunter--update--path)
 
-##### <a name="method"></a>`method`
+##### <a name="-rkhunter--update--method"></a>`method`
 
 Data type: `Enum['cron','systemd']`
 
@@ -1104,7 +1104,7 @@ How you wish to schedule the run
 
 Default value: `'systemd'`
 
-##### <a name="systemd_calendar"></a>`systemd_calendar`
+##### <a name="-rkhunter--update--systemd_calendar"></a>`systemd_calendar`
 
 Data type: `Optional[String[1]]`
 
@@ -1113,9 +1113,9 @@ If `$method` is `systemd`, set this exact calendar string
 This is not verified, use `systemd-analyze calendar` on a modern system to
 ensure that you have a valid string
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="minute"></a>`minute`
+##### <a name="-rkhunter--update--minute"></a>`minute`
 
 Data type: `Simplib::Cron::Minute`
 
@@ -1123,7 +1123,7 @@ Cron minute
 
 Default value: `fqdn_rand(59)`
 
-##### <a name="hour"></a>`hour`
+##### <a name="-rkhunter--update--hour"></a>`hour`
 
 Data type: `Simplib::Cron::Hour`
 
@@ -1131,7 +1131,7 @@ Cron hour
 
 Default value: `0`
 
-##### <a name="monthday"></a>`monthday`
+##### <a name="-rkhunter--update--monthday"></a>`monthday`
 
 Data type: `Simplib::Cron::MonthDay`
 
@@ -1139,7 +1139,7 @@ Cron monthday
 
 Default value: `'*'`
 
-##### <a name="month"></a>`month`
+##### <a name="-rkhunter--update--month"></a>`month`
 
 Data type: `Simplib::Cron::Month`
 
@@ -1147,7 +1147,7 @@ Cron month
 
 Default value: `'*'`
 
-##### <a name="weekday"></a>`weekday`
+##### <a name="-rkhunter--update--weekday"></a>`weekday`
 
 Data type: `Simplib::Cron::Weekday`
 
@@ -1155,7 +1155,7 @@ Cron weekday
 
 Default value: `'*'`
 
-##### <a name="options"></a>`options`
+##### <a name="-rkhunter--update--options"></a>`options`
 
 Data type: `Array[String[1]]`
 
@@ -1163,7 +1163,7 @@ Extra options to pass to `rkhunter --update`
 
 Default value: `['--nocolors']`
 
-##### <a name="path"></a>`path`
+##### <a name="-rkhunter--update--path"></a>`path`
 
 Data type: `Stdlib::Unixpath`
 
@@ -1173,15 +1173,11 @@ Default value: `'/usr/bin/rkhunter'`
 
 ## Data types
 
-### <a name="rkhunterbindpath"></a>`Rkhunter::BindPath`
+### <a name="Rkhunter--BindPath"></a>`Rkhunter::BindPath`
 
 matches valid binddir path
 accepts absolute path or an absolute path
 with a '+' proceeding it
 
-Alias of
-
-```puppet
-Pattern['^(?:\/|\+\/)(?:[^\/\0]+\/*)*$']
-```
+Alias of `Pattern['^(?:\/|\+\/)(?:[^\/\0]+\/*)*$']`
 


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.