### PR TITLE
[puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 0.5.0
+- [puppetsync] Add EL9 support
+
 * Wed Oct 11 2023 Steven Pritchard <steve@sicura.us> - 0.4.0
 - [puppetsync] Updates for Puppet 8
   - These updates may include the following:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
-* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 0.5.0
-- [puppetsync] Add EL9 support
+* Wed Feb 07 2024 Mike Riddle <mike@sicura.us> - 0.5.0
+- [puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd
 
 * Wed Oct 11 2023 Steven Pritchard <steve@sicura.us> - 0.4.0
 - [puppetsync] Updates for Puppet 8

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,6 +1,3 @@
 ---
-rkhunter::install_optional_packages: true
-  
-rkhunter::install::optional_packages:
-  - unhide
+rkhunter::install_optional_packages: false
 

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -1,0 +1,5 @@
+---
+rkhunter::install_optional_packages: true
+
+rkhunter::install::optional_packages:
+    - unhide

--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -1,2 +1,0 @@
----
-rkhunter::install_optional_packages: false

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rkhunter",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing rkhunter",
   "license": "Apache-2.0",
@@ -25,33 +25,38 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     }
   ],


### PR DESCRIPTION
The patch enforces a standardized asset baseline using
simp/puppetsync, and may also apply other updates to
ensure conformity.